### PR TITLE
Assign source PR assignees to generated release PRs

### DIFF
--- a/flow/process.go
+++ b/flow/process.go
@@ -114,8 +114,9 @@ func (f *Flow) processAttempt(ctx context.Context, client *github.Client, app *A
 	for oldVersion := range oldVersionSet {
 		oldVersions = append(oldVersions, oldVersion)
 	}
-	body := generateBody(ctx, client, app, manifest, version, oldVersions)
+	body, assignees := generateBody(ctx, client, app, manifest, version, oldVersions)
 	release.SetBody(body)
+	release.SetAssignees(assignees)
 
 	err := release.Commit(ctx, client)
 	if err != nil {
@@ -307,8 +308,10 @@ func getApplicationByImage(image string) (*Application, error) {
 	return nil, errors.New("No application found for image " + image)
 }
 
-func generateBody(ctx context.Context, client *github.Client, app *Application, manifest Manifest, version string, oldVersions []string) string {
+func generateBody(ctx context.Context, client *github.Client, app *Application, manifest Manifest, version string, oldVersions []string) (string, []string) {
 	var body string
+	assigneeSet := map[string]struct{}{}
+	var assignees []string
 
 	if !manifest.HideSourceReleaseDesc {
 		body += "# Release\n"
@@ -350,6 +353,17 @@ func generateBody(ctx context.Context, client *github.Client, app *Application, 
 						continue
 					}
 					body += fmt.Sprintf("- %s by @%s in %s/%s#%d\n", *pr.Title, *pr.User.Login, app.SourceOwner, app.SourceName, *pr.Number)
+					for _, a := range pr.Assignees {
+						if a == nil || a.Login == nil {
+							continue
+						}
+						login := *a.Login
+						if _, ok := assigneeSet[login]; ok {
+							continue
+						}
+						assigneeSet[login] = struct{}{}
+						assignees = append(assignees, login)
+					}
 				}
 				body += "\n"
 			}
@@ -361,5 +375,5 @@ func generateBody(ctx context.Context, client *github.Client, app *Application, 
 		body += fmt.Sprintf("\n---\n%s", manifest.PRBody)
 	}
 
-	return body
+	return body, assignees
 }

--- a/gitbot/commitpr.go
+++ b/gitbot/commitpr.go
@@ -92,11 +92,23 @@ func (r *release) createPR(ctx context.Context, client *github.Client) (*string,
 		slog.Error("Error adding labels", "error", err)
 	}
 
+	if err := r.addAssignees(ctx, client, *pr.Number); err != nil {
+		slog.Error("Error adding assignees", "error", err)
+	}
+
 	return github.Ptr(pr.GetHTMLURL()), nil
 }
 
 func (r *release) addLabels(ctx context.Context, client *github.Client, prNumber int) error {
 	_, _, err := client.Issues.AddLabelsToIssue(ctx, r.repo.SourceOwner, r.repo.SourceRepo, prNumber, r.labels)
+	return err
+}
+
+func (r *release) addAssignees(ctx context.Context, client *github.Client, prNumber int) error {
+	if len(r.assignees) == 0 {
+		return nil
+	}
+	_, _, err := client.Issues.AddAssignees(ctx, r.repo.SourceOwner, r.repo.SourceRepo, prNumber, r.assignees)
 	return err
 }
 

--- a/gitbot/release.go
+++ b/gitbot/release.go
@@ -14,6 +14,7 @@ type release struct {
 	message           string
 	body              string
 	labels            []string
+	assignees         []string
 	changedContentMap map[string]string
 }
 
@@ -33,6 +34,8 @@ type Release interface {
 	SetBody(string)
 	GetLabels() []string
 	SetLabels([]string)
+	GetAssignees() []string
+	SetAssignees([]string)
 }
 
 type Repo struct {
@@ -89,13 +92,15 @@ func (r *release) CreatePR(ctx context.Context, client *github.Client) (*string,
 	return r.createPR(ctx, client)
 }
 
-func (r *release) GetRepo() *Repo            { return &r.repo }
-func (r *release) SetRepo(repo Repo)         { r.repo = repo }
-func (r *release) GetAuthor() *Author        { return &r.author }
-func (r *release) SetAuthor(author Author)   { r.author = author }
-func (r *release) GetMessage() string        { return r.message }
-func (r *release) SetMessage(s string)       { r.message = s }
-func (r *release) GetBody() string           { return r.body }
-func (r *release) SetBody(s string)          { r.body = s }
-func (r *release) GetLabels() []string       { return r.labels }
-func (r *release) SetLabels(labels []string) { r.labels = labels }
+func (r *release) GetRepo() *Repo                  { return &r.repo }
+func (r *release) SetRepo(repo Repo)               { r.repo = repo }
+func (r *release) GetAuthor() *Author              { return &r.author }
+func (r *release) SetAuthor(author Author)         { r.author = author }
+func (r *release) GetMessage() string              { return r.message }
+func (r *release) SetMessage(s string)             { r.message = s }
+func (r *release) GetBody() string                 { return r.body }
+func (r *release) SetBody(s string)                { r.body = s }
+func (r *release) GetLabels() []string             { return r.labels }
+func (r *release) SetLabels(labels []string)       { r.labels = labels }
+func (r *release) GetAssignees() []string          { return r.assignees }
+func (r *release) SetAssignees(assignees []string) { r.assignees = assignees }


### PR DESCRIPTION
## Summary

- Generated release/manifest PRs now inherit assignees from the source PRs they bundle.
- `generateBody` collects the unique union of `pr.Assignees[].Login` from each source PR fetched while building the body, and returns them alongside the body.
- `processAttempt` plumbs that list into the `Release` via the new `SetAssignees` setter; `createPR` calls `Issues.AddAssignees` after creating the PR (errors are logged, not fatal — same pattern as `addLabels`).
- When source PRs have no assignees (or when `HideSourceReleaseDesc` / `HideSourceReleasePullRequests` skip the PR fetch), behavior is unchanged: no assignees are set.

## Test plan

- [ ] Existing `flow/process_test.go` continues to pass (`go test ./...`).
- [ ] Trigger a release where a source PR has an assignee — generated release PR should be assigned to that user.
- [ ] Trigger a release where the source PRs have no assignees — PR is created without assignees, as before.
- [ ] Trigger a release whose source PRs collectively have multiple distinct assignees — all unique logins are applied, no duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)