### PR TITLE
Propagate clouddeploy-auto-approve(_wait-for-e2e) from source Release marker

### DIFF
--- a/flow/auto_approve.go
+++ b/flow/auto_approve.go
@@ -1,0 +1,60 @@
+package flow
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/google/go-github/v75/github"
+)
+
+const (
+	// autoApproveMarker is an opt-in marker embedded in a source GitHub Release body
+	// (e.g. by gh-release --auto-approve). Exact match only — do not loosen this string.
+	autoApproveMarker = "<!-- ubie:auto-approve -->"
+	// cloudDeployAutoApproveLabel is applied to the releases PR when the marker is present.
+	// Downstream (github-pr-finder / cloudbuild-utils) consumes this label.
+	cloudDeployAutoApproveLabel = "clouddeploy-auto-approve"
+)
+
+// containsAutoApproveMarker reports whether body contains the exact auto-approve marker.
+// Matching the full marker string avoids false positives from partial substrings.
+func containsAutoApproveMarker(body string) bool {
+	return strings.Contains(body, autoApproveMarker)
+}
+
+// maybePropagateAutoApproveLabel fetches the source GitHub Release for tag and, when its
+// body contains the auto-approve marker, appends clouddeploy-auto-approve to labels.
+// Any failure (API error, missing release, empty body, no marker) is logged and ignored
+// so image rewrite / commit / PR creation continues without the label.
+func maybePropagateAutoApproveLabel(ctx context.Context, client *github.Client, owner, repo, tag string, labels []string) []string {
+	if !hasAutoApproveMarkerInRelease(ctx, client, owner, repo, tag) {
+		return labels
+	}
+	return append(labels, cloudDeployAutoApproveLabel)
+}
+
+func hasAutoApproveMarkerInRelease(ctx context.Context, client *github.Client, owner, repo, tag string) bool {
+	rel, _, err := client.Repositories.GetReleaseByTag(ctx, owner, repo, tag)
+	if err != nil {
+		slog.Warn("Failed to get GitHub Release for auto-approve marker; continuing without label",
+			"owner", owner, "repo", repo, "tag", tag, "error", err)
+		return false
+	}
+	if rel == nil {
+		slog.Info("GitHub Release is nil for auto-approve marker; continuing without label",
+			"owner", owner, "repo", repo, "tag", tag)
+		return false
+	}
+
+	// GetBody returns "" when Body is nil.
+	if !containsAutoApproveMarker(rel.GetBody()) {
+		slog.Info("auto-approve marker not present in Release body; continuing without label",
+			"owner", owner, "repo", repo, "tag", tag)
+		return false
+	}
+
+	slog.Info("Found auto-approve marker in Release body; adding label",
+		"owner", owner, "repo", repo, "tag", tag, "label", cloudDeployAutoApproveLabel)
+	return true
+}

--- a/flow/auto_approve.go
+++ b/flow/auto_approve.go
@@ -12,49 +12,87 @@ const (
 	// autoApproveMarker is an opt-in marker embedded in a source GitHub Release body
 	// (e.g. by gh-release --auto-approve). Exact match only — do not loosen this string.
 	autoApproveMarker = "<!-- ubie:auto-approve -->"
-	// cloudDeployAutoApproveLabel is applied to the releases PR when the marker is present.
+	// autoApproveWaitForE2EMarker is the wait-for-e2e variant (gh-release -a -w).
+	// Exact match only — do not loosen this string.
+	autoApproveWaitForE2EMarker = "<!-- ubie:auto-approve-wait-for-e2e -->"
+	// cloudDeployAutoApproveLabel is applied to the releases PR when the normal marker is present.
 	// Downstream (github-pr-finder / cloudbuild-utils) consumes this label.
 	cloudDeployAutoApproveLabel = "clouddeploy-auto-approve"
+	// cloudDeployAutoApproveWaitForE2ELabel is applied when the wait-for-e2e marker is present.
+	cloudDeployAutoApproveWaitForE2ELabel = "clouddeploy-auto-approve-wait-for-e2e"
 )
 
-// containsAutoApproveMarker reports whether body contains the exact auto-approve marker.
+type autoApproveKind int
+
+const (
+	autoApproveNone autoApproveKind = iota
+	autoApproveNormal
+	autoApproveWaitForE2E
+)
+
+// detectAutoApproveMarker reports which auto-approve marker is present.
+// Markers are mutually exclusive; if both appear, prefer wait-for-e2e (safer).
+func detectAutoApproveMarker(body string) autoApproveKind {
+	hasWait := strings.Contains(body, autoApproveWaitForE2EMarker)
+	hasNormal := strings.Contains(body, autoApproveMarker)
+	if hasWait {
+		return autoApproveWaitForE2E
+	}
+	if hasNormal {
+		return autoApproveNormal
+	}
+	return autoApproveNone
+}
+
+// containsAutoApproveMarker reports whether body contains the exact normal auto-approve marker.
 // Matching the full marker string avoids false positives from partial substrings.
 func containsAutoApproveMarker(body string) bool {
-	return strings.Contains(body, autoApproveMarker)
+	return detectAutoApproveMarker(body) == autoApproveNormal
 }
 
 // maybePropagateAutoApproveLabel fetches the source GitHub Release for tag and, when its
-// body contains the auto-approve marker, appends clouddeploy-auto-approve to labels.
+// body contains an auto-approve marker, appends the corresponding label.
+// Wait marker → clouddeploy-auto-approve-wait-for-e2e only.
+// Normal marker → clouddeploy-auto-approve only.
 // Any failure (API error, missing release, empty body, no marker) is logged and ignored
 // so image rewrite / commit / PR creation continues without the label.
 func maybePropagateAutoApproveLabel(ctx context.Context, client *github.Client, owner, repo, tag string, labels []string) []string {
-	if !hasAutoApproveMarkerInRelease(ctx, client, owner, repo, tag) {
+	kind := detectAutoApproveMarkerInRelease(ctx, client, owner, repo, tag)
+	switch kind {
+	case autoApproveWaitForE2E:
+		return append(labels, cloudDeployAutoApproveWaitForE2ELabel)
+	case autoApproveNormal:
+		return append(labels, cloudDeployAutoApproveLabel)
+	default:
 		return labels
 	}
-	return append(labels, cloudDeployAutoApproveLabel)
 }
 
-func hasAutoApproveMarkerInRelease(ctx context.Context, client *github.Client, owner, repo, tag string) bool {
+func detectAutoApproveMarkerInRelease(ctx context.Context, client *github.Client, owner, repo, tag string) autoApproveKind {
 	rel, _, err := client.Repositories.GetReleaseByTag(ctx, owner, repo, tag)
 	if err != nil {
 		slog.Warn("Failed to get GitHub Release for auto-approve marker; continuing without label",
 			"owner", owner, "repo", repo, "tag", tag, "error", err)
-		return false
+		return autoApproveNone
 	}
 	if rel == nil {
 		slog.Info("GitHub Release is nil for auto-approve marker; continuing without label",
 			"owner", owner, "repo", repo, "tag", tag)
-		return false
+		return autoApproveNone
 	}
 
 	// GetBody returns "" when Body is nil.
-	if !containsAutoApproveMarker(rel.GetBody()) {
+	kind := detectAutoApproveMarker(rel.GetBody())
+	switch kind {
+	case autoApproveWaitForE2E:
+		slog.Info("Found auto-approve-wait-for-e2e marker in Release body; adding label",
+			"owner", owner, "repo", repo, "tag", tag, "label", cloudDeployAutoApproveWaitForE2ELabel)
+	case autoApproveNormal:
+		slog.Info("Found auto-approve marker in Release body; adding label",
+			"owner", owner, "repo", repo, "tag", tag, "label", cloudDeployAutoApproveLabel)
+	default:
 		slog.Info("auto-approve marker not present in Release body; continuing without label",
 			"owner", owner, "repo", repo, "tag", tag)
-		return false
 	}
-
-	slog.Info("Found auto-approve marker in Release body; adding label",
-		"owner", owner, "repo", repo, "tag", tag, "label", cloudDeployAutoApproveLabel)
-	return true
+	return kind
 }

--- a/flow/auto_approve_test.go
+++ b/flow/auto_approve_test.go
@@ -14,27 +14,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestContainsAutoApproveMarker(t *testing.T) {
+func TestDetectAutoApproveMarker(t *testing.T) {
 	tests := []struct {
 		name string
 		body string
-		want bool
+		want autoApproveKind
 	}{
-		{name: "exact marker only", body: autoApproveMarker, want: true},
-		{name: "marker at end of body", body: "Release notes\n\n" + autoApproveMarker + "\n", want: true},
-		{name: "marker in middle", body: "before\n" + autoApproveMarker + "\nafter", want: true},
-		{name: "empty body", body: "", want: false},
-		{name: "partial without html comment", body: "ubie:auto-approve", want: false},
-		{name: "similar wrong marker", body: "<!-- ubie:auto-approve-all -->", want: false},
-		{name: "missing closing", body: "<!-- ubie:auto-approve", want: false},
-		{name: "different marker", body: "<!-- auto-approve -->", want: false},
-		{name: "unrelated body", body: "normal release notes", want: false},
+		{name: "exact normal marker only", body: autoApproveMarker, want: autoApproveNormal},
+		{name: "exact wait marker only", body: autoApproveWaitForE2EMarker, want: autoApproveWaitForE2E},
+		{name: "normal marker at end of body", body: "Release notes\n\n" + autoApproveMarker + "\n", want: autoApproveNormal},
+		{name: "wait marker at end of body", body: "Release notes\n\n" + autoApproveWaitForE2EMarker + "\n", want: autoApproveWaitForE2E},
+		{name: "both markers prefers wait", body: autoApproveMarker + "\n" + autoApproveWaitForE2EMarker, want: autoApproveWaitForE2E},
+		{name: "both markers reverse order prefers wait", body: autoApproveWaitForE2EMarker + "\n" + autoApproveMarker, want: autoApproveWaitForE2E},
+		{name: "empty body", body: "", want: autoApproveNone},
+		{name: "partial without html comment", body: "ubie:auto-approve", want: autoApproveNone},
+		{name: "similar wrong marker", body: "<!-- ubie:auto-approve-all -->", want: autoApproveNone},
+		{name: "missing closing", body: "<!-- ubie:auto-approve", want: autoApproveNone},
+		{name: "different marker", body: "<!-- auto-approve -->", want: autoApproveNone},
+		{name: "unrelated body", body: "normal release notes", want: autoApproveNone},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, containsAutoApproveMarker(tc.body))
+			assert.Equal(t, tc.want, detectAutoApproveMarker(tc.body))
 		})
 	}
+}
+
+func TestContainsAutoApproveMarker(t *testing.T) {
+	assert.True(t, containsAutoApproveMarker(autoApproveMarker))
+	assert.False(t, containsAutoApproveMarker(autoApproveWaitForE2EMarker))
+	assert.False(t, containsAutoApproveMarker(""))
 }
 
 func TestMaybePropagateAutoApproveLabel(t *testing.T) {
@@ -52,10 +61,22 @@ func TestMaybePropagateAutoApproveLabel(t *testing.T) {
 		wantLabels []string
 	}{
 		{
-			name:       "marker present adds label",
+			name:       "normal marker present adds normal label",
 			status:     http.StatusOK,
 			body:       github.Ptr("notes\n" + autoApproveMarker + "\n"),
 			wantLabels: []string{"alice", "production", cloudDeployAutoApproveLabel},
+		},
+		{
+			name:       "wait marker present adds wait label only",
+			status:     http.StatusOK,
+			body:       github.Ptr("notes\n" + autoApproveWaitForE2EMarker + "\n"),
+			wantLabels: []string{"alice", "production", cloudDeployAutoApproveWaitForE2ELabel},
+		},
+		{
+			name:       "both markers prefers wait label only",
+			status:     http.StatusOK,
+			body:       github.Ptr(autoApproveMarker + "\n" + autoApproveWaitForE2EMarker),
+			wantLabels: []string{"alice", "production", cloudDeployAutoApproveWaitForE2ELabel},
 		},
 		{
 			name:       "marker absent keeps labels",

--- a/flow/auto_approve_test.go
+++ b/flow/auto_approve_test.go
@@ -1,0 +1,115 @@
+package flow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-github/v75/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainsAutoApproveMarker(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "exact marker only", body: autoApproveMarker, want: true},
+		{name: "marker at end of body", body: "Release notes\n\n" + autoApproveMarker + "\n", want: true},
+		{name: "marker in middle", body: "before\n" + autoApproveMarker + "\nafter", want: true},
+		{name: "empty body", body: "", want: false},
+		{name: "partial without html comment", body: "ubie:auto-approve", want: false},
+		{name: "similar wrong marker", body: "<!-- ubie:auto-approve-all -->", want: false},
+		{name: "missing closing", body: "<!-- ubie:auto-approve", want: false},
+		{name: "different marker", body: "<!-- auto-approve -->", want: false},
+		{name: "unrelated body", body: "normal release notes", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, containsAutoApproveMarker(tc.body))
+		})
+	}
+}
+
+func TestMaybePropagateAutoApproveLabel(t *testing.T) {
+	const (
+		owner = "wonderland"
+		repo  = "alice"
+		tag   = "v1.2.3"
+	)
+	baseLabels := []string{"alice", "production"}
+
+	tests := []struct {
+		name       string
+		status     int
+		body       *string
+		wantLabels []string
+	}{
+		{
+			name:       "marker present adds label",
+			status:     http.StatusOK,
+			body:       github.Ptr("notes\n" + autoApproveMarker + "\n"),
+			wantLabels: []string{"alice", "production", cloudDeployAutoApproveLabel},
+		},
+		{
+			name:       "marker absent keeps labels",
+			status:     http.StatusOK,
+			body:       github.Ptr("normal release notes"),
+			wantLabels: baseLabels,
+		},
+		{
+			name:       "nil body keeps labels",
+			status:     http.StatusOK,
+			body:       nil,
+			wantLabels: baseLabels,
+		},
+		{
+			name:       "empty body keeps labels",
+			status:     http.StatusOK,
+			body:       github.Ptr(""),
+			wantLabels: baseLabels,
+		},
+		{
+			name:       "release not found keeps labels",
+			status:     http.StatusNotFound,
+			wantLabels: baseLabels,
+		},
+		{
+			name:       "api error keeps labels",
+			status:     http.StatusInternalServerError,
+			wantLabels: baseLabels,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/releases/tags/%s", owner, repo, tag), func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				w.WriteHeader(tc.status)
+				if tc.status != http.StatusOK {
+					_, _ = w.Write([]byte(`{"message":"error"}`))
+					return
+				}
+				rel := &github.RepositoryRelease{TagName: github.Ptr(tag), Body: tc.body}
+				require.NoError(t, json.NewEncoder(w).Encode(rel))
+			})
+			server := httptest.NewServer(mux)
+			t.Cleanup(server.Close)
+
+			client := github.NewClient(server.Client())
+			baseURL, err := url.Parse(server.URL + "/")
+			require.NoError(t, err)
+			client.BaseURL = baseURL
+
+			got := maybePropagateAutoApproveLabel(context.Background(), client, owner, repo, tag, append([]string{}, baseLabels...))
+			assert.Equal(t, tc.wantLabels, got)
+		})
+	}
+}

--- a/flow/process.go
+++ b/flow/process.go
@@ -117,6 +117,9 @@ func (f *Flow) processAttempt(ctx context.Context, client *github.Client, app *A
 	body, assignees := generateBody(ctx, client, app, manifest, version, oldVersions)
 	release.SetBody(body)
 	release.SetAssignees(assignees)
+	// Best-effort: propagate clouddeploy-auto-approve from source Release body marker.
+	// Failures must not block image rewrite / commit / PR creation.
+	release.SetLabels(maybePropagateAutoApproveLabel(ctx, client, app.SourceOwner, app.SourceName, version, release.GetLabels()))
 
 	err := release.Commit(ctx, client)
 	if err != nil {

--- a/flow/process.go
+++ b/flow/process.go
@@ -117,8 +117,8 @@ func (f *Flow) processAttempt(ctx context.Context, client *github.Client, app *A
 	body, assignees := generateBody(ctx, client, app, manifest, version, oldVersions)
 	release.SetBody(body)
 	release.SetAssignees(assignees)
-	// Best-effort: propagate clouddeploy-auto-approve from source Release body marker.
-	// Failures must not block image rewrite / commit / PR creation.
+	// Best-effort: propagate clouddeploy-auto-approve(_wait-for-e2e) from source Release body marker.
+	// Failures / missing markers must not block image rewrite / commit / PR creation.
 	release.SetLabels(maybePropagateAutoApproveLabel(ctx, client, app.SourceOwner, app.SourceName, version, release.GetLabels()))
 
 	err := release.Commit(ctx, client)


### PR DESCRIPTION
## Summary

### What
source image version/tag に対応する GitHub Release を source owner/repo から取得し、Release body の marker に応じて releases PR へ label を best-effort 伝播する。

| Release body marker | PR label |
|---------------------|----------|
| `<!-- ubie:auto-approve -->` | `clouddeploy-auto-approve` |
| `<!-- ubie:auto-approve-wait-for-e2e -->` | `clouddeploy-auto-approve-wait-for-e2e` |

### Why
gh-release の `--auto-approve` / `-a` と `--wait-for-e2e` / `-w` で埋め込まれた marker を downstream（github-pr-finder → Cloud Build / cloudbuild-utils → uotify）へ伝播し、Cloud Deploy prd の自動承認（および E2E wait）を opt-in で有効にするため。

### Behavior / 原子的伝播
- 通常 marker → 通常 label のみ
- wait marker → wait label のみ
- **相互排他**: 万一両方の marker がある場合は安全側で wait label のみ（通常 label を付けない）
- marker なし → 従来どおり（label なし）

### Fail-safe
- Release 取得失敗 / 不存在 / body nil / marker なしでも image rewrite・commit・PR 作成は止めない（warn/info log 後に label なしで継続）
- 既存の label 付与失敗時の fail-safe（PR 作成自体は成功扱い）は維持

### 依存
- 上流: gh-release（marker 埋め込み）
- 下流: cloudbuild-utils（label → `AUTO_APPROVE` / `WAIT_FOR_E2E`）
- 本 PR 単独 merge は安全。marker がなければ no-op

### Tests
- 通常 / wait marker あり/なし（false positive 回避含む）
- 両 marker 時は wait label のみ
- Release API error / 404 / nil・empty body でも通常 labels のまま継続

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run --disable govet ./...`
- [x] `go build`
- [x] CI (Go / golangci-lint) green

Made with [Cursor](https://cursor.com)
